### PR TITLE
Improve script and GitHub Action

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,23 +5,39 @@ on:
     branches:
       - master
   workflow_dispatch:
-  
   schedule:
     - cron: "0 */4 * * *"
 
+concurrency:
+  group: update-readme
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
 jobs:
-  build:
+  update-readme:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     steps:
     - uses: actions/checkout@v4
+
+    - uses: pnpm/action-setup@v4
+      with:
+        version: 10
+
     - uses: actions/setup-node@v4
       with:
         node-version: '22'
-    - run: npm run update-readme
+        cache: 'pnpm'
+
+    - run: pnpm install --frozen-lockfile
+
+    - run: pnpm run update-readme
       env:
-        INSTAGRAM_API_KEY: ${{ secrets.INSTAGRAM_API_KEY }}
         YOUTUBE_API_KEY: ${{ secrets.YOUTUBE_API_KEY }}
+
     - run: |
         git config user.name midudev
         git config user.email miduga@gmail.com

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,14 +1,10 @@
 export const NUMBER_OF = Object.freeze({
-  ARTICLES: 5,
-  PHOTOS: 4,
   VIDEOS: 3
 })
 
 export const PLACEHOLDERS = Object.freeze({
-  LATEST_ARTICLES: '%{{latest_articles}}%',
   LATEST_YOUTUBE: '%{{latest_youtube}}%',
-  LATEST_YOUTUBE_SECONDARY: '%{{latest_youtube_secondary}}%',
-  LATEST_INSTAGRAM: '%{{latest_instagram}}%'
+  LATEST_YOUTUBE_SECONDARY: '%{{latest_youtube_secondary}}%'
 })
 
 export const YOUTUBE_CHANNEL_IDS = Object.freeze({

--- a/src/index.js
+++ b/src/index.js
@@ -1,90 +1,65 @@
-import { promises as fs } from 'fs'
+import { promises as fs } from 'node:fs'
 
 import { PLACEHOLDERS, NUMBER_OF, YOUTUBE_CHANNEL_IDS } from './constants.js'
 
-const {
-  // INSTAGRAM_API_KEY,
-  // TWITCH_API_CLIENT_KEY,
-  // TWITCH_API_SECRET_KEY,
-  YOUTUBE_API_KEY
-} = process.env
+const FETCH_TIMEOUT_MS = 10_000
 
-// const INSTAGRAM_USER_ID = '8242141302'
+const { YOUTUBE_API_KEY } = process.env
 
-// const authProvider = new ClientCredentialsAuthProvider(TWITCH_API_CLIENT_KEY, TWITCH_API_SECRET_KEY)
-// const apiClient = new ApiClient({ authProvider })
+if (!YOUTUBE_API_KEY) {
+  console.error('❌ Missing YOUTUBE_API_KEY environment variable')
+  process.exit(1)
+}
 
-// const getLatestTwitchStream = async () => {
-//   const response = await apiClient.kraken.channels.getChannel('midudev')
-//   console.log(response)
-// }
+async function getLatestYoutubeVideos (channelId = YOUTUBE_CHANNEL_IDS.MIDUDEV) {
+  const url = `https://www.googleapis.com/youtube/v3/playlistItems?part=snippet&playlistId=${channelId}&maxResults=${NUMBER_OF.VIDEOS}&key=${YOUTUBE_API_KEY}`
+  const res = await fetch(url, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) })
 
-// const getPhotosFromInstagram = async () => {
-//   const response = await fetch(`https://instagram130.p.rapidapi.com/account-medias?userid=${INSTAGRAM_USER_ID}&first=20`, {
-//     headers: {
-//       'x-rapidapi-host': 'instagram130.p.rapidapi.com',
-//       'x-rapidapi-key': INSTAGRAM_API_KEY
-//     }
-//   })
+  if (!res.ok) {
+    throw new Error(`YouTube API error: ${res.status} ${res.statusText}`)
+  }
 
-//   const json = await response.json()
+  const { items } = await res.json()
+  return items
+}
 
-//   return json?.edges
-// }
-
-const getLatestYoutubeVideos = ({ channelId } = { channelId: YOUTUBE_CHANNEL_IDS.MIDUDEV }) =>
-  fetch(
-    `https://www.googleapis.com/youtube/v3/playlistItems?part=snippet&playlistId=${channelId}&maxResults=${NUMBER_OF.VIDEOS}&key=${YOUTUBE_API_KEY}`
-  )
-    .then((res) => res.json())
-    .then((videos) => videos.items)
-
-// const generateInstagramHTML = ({ node: { display_url: url, shortcode } }) => `
-// <a href='https://instagram.com/p/${shortcode}' target='_blank'>
-//   <img width='20%' src='${url}' alt='Instagram photo' />
-// </a>`
-
-const generateYoutubeHTML = ({ title, videoId }) => {
-  // Escapar comillas simples y eliminar saltos de línea en el título
-  const safeTitle = title.replace(/'/g, "\\'").replace(/\n/g, ' ')
-
+function generateYoutubeHTML ({ title, videoId }) {
+  const safeTitle = title.replace(/'/g, '&#39;').replace(/\n/g, ' ')
   return `
 <a href='https://youtu.be/${videoId}' target='_blank'>
   <img width='30%' src='https://img.youtube.com/vi/${videoId}/mqdefault.jpg' alt='${safeTitle}' />
 </a>`
-};
+}
 
-(async () => {
-  // await getLatestTwitchStream()
+function videosToHTML (videos) {
+  return videos
+    .map(({ snippet }) => generateYoutubeHTML({
+      title: snippet.title,
+      videoId: snippet.resourceId.videoId
+    }))
+    .join('')
+}
 
-  const [template, videos, secondaryChannelVideos] = await Promise.all([
+async function main () {
+  console.log('⏳ Fetching latest YouTube videos…')
+
+  const [template, videos, secondaryVideos] = await Promise.all([
     fs.readFile('./src/README.md.tpl', { encoding: 'utf-8' }),
     getLatestYoutubeVideos(),
-    getLatestYoutubeVideos({ channelId: YOUTUBE_CHANNEL_IDS.MIDULIVE })
+    getLatestYoutubeVideos(YOUTUBE_CHANNEL_IDS.MIDULIVE)
   ])
 
-  // create latest youtube videos channel
-  const latestYoutubeVideos = videos
-    .map(({ snippet }) => {
-      const { title, resourceId } = snippet
-      const { videoId } = resourceId
-      return generateYoutubeHTML({ videoId, title })
-    })
-    .join('')
+  console.log(`✅ Fetched ${videos.length} + ${secondaryVideos.length} videos`)
 
-  // create latest youtube videos secondary channel
-  const latestYoutubeSecondaryChannelVideos = secondaryChannelVideos
-    .map(({ snippet }) => {
-      const { title, resourceId } = snippet
-      const { videoId } = resourceId
-      return generateYoutubeHTML({ videoId, title })
-    })
-    .join('')
-
-  // replace all placeholders with info
   const newMarkdown = template
-    .replace(PLACEHOLDERS.LATEST_YOUTUBE, latestYoutubeVideos)
-    .replace(PLACEHOLDERS.LATEST_YOUTUBE_SECONDARY, latestYoutubeSecondaryChannelVideos)
+    .replace(PLACEHOLDERS.LATEST_YOUTUBE, videosToHTML(videos))
+    .replace(PLACEHOLDERS.LATEST_YOUTUBE_SECONDARY, videosToHTML(secondaryVideos))
 
   await fs.writeFile('README.md', newMarkdown)
-})()
+  console.log('✅ README.md updated successfully')
+}
+
+main().catch((error) => {
+  console.error('❌ Failed to update README:', error.message)
+  process.exit(1)
+})


### PR DESCRIPTION
## Why

The update-readme script had accumulated dead code (Instagram/Twitch integrations), lacked error handling, and the GitHub Action used npm despite the project having a `pnpm-lock.yaml`. These issues made the workflow harder to maintain and debug when failures occurred.

## What changed

### Script (`src/index.js`)
- **Removed all dead code** — commented-out Instagram and Twitch integrations that were never going to be re-enabled
- **Added error handling** — validates `YOUTUBE_API_KEY` at startup, checks `res.ok` before parsing JSON, and uses `AbortSignal.timeout(10s)` to prevent hanging fetches
- **Refactored structure** — replaced anonymous IIFE with an explicit `main()` function with `.catch()` for cleaner stack traces and error reporting
- **Extracted `videosToHTML()` helper** — eliminates duplicated video-to-HTML mapping logic for both channels
- **Added progress logging** — emoji-prefixed console output for CI visibility

### Constants (`src/constants.js`)
- Removed unused `ARTICLES`, `PHOTOS`, `LATEST_ARTICLES`, and `LATEST_INSTAGRAM` constants

### GitHub Action (`.github/workflows/node.js.yml`)
- **Switched to pnpm** with `pnpm/action-setup@v4` + `pnpm install --frozen-lockfile` (matching the existing lockfile)
- **Added pnpm cache** via `actions/setup-node` `cache: 'pnpm'` for faster CI runs
- **Added `concurrency`** group to cancel overlapping runs
- **Added `permissions: contents: write`** (least privilege)
- **Added `timeout-minutes: 5`** to prevent stuck jobs
- **Removed unused `INSTAGRAM_API_KEY`** secret reference
- **Renamed job** from `build` to `update-readme` for clarity