### PR TITLE
fix: twitter logo url in readme.md

### DIFF
--- a/src/README.md.tpl
+++ b/src/README.md.tpl
@@ -17,7 +17,7 @@
   </a>
   <span style="width: 8px;"> </span>
   <a href="https://twitter.com/midudev" target="blank">
-    <img align="center" src="https://upload.wikimedia.org/wikipedia/commons/thumb/6/6f/Logo_of_Twitter.svg/2491px-Logo_of_Twitter.svg.png" alt="Canal de Twitter de midudev" height="23px" width="28px" />
+    <img align="center" src="https://upload.wikimedia.org/wikipedia/commons/6/6f/Logo_of_Twitter.svg" alt="Canal de Twitter de midudev" height="23px" width="28px" />
   </a>
 </p>
 


### PR DESCRIPTION
El error no se encontraba en el README original, sino en el que finaliza con .tpl.